### PR TITLE
BUG fix - fixes #6

### DIFF
--- a/portfolio/src/components/MiniTerminalLink.js
+++ b/portfolio/src/components/MiniTerminalLink.js
@@ -15,6 +15,7 @@ const StyledTerminalLink = styled.div`
   animation-duration: 1.5s;
   animation-iteration-count: 2;
   animation-direction: alternate-reverse;
+  z-index: 99;
 
   &:before {
     content: "";


### PR DESCRIPTION
Changed z-index for MiniTerminalLink div to make it place on top of any other element. So that no other element captures hover event ahead of this.